### PR TITLE
expose stateChangedHandler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
 
     dependencies: [
-        .package(url: "https://github.com/orchetect/MIDIKit", from: "0.3.0"),
+        .package(url: "https://github.com/orchetect/MIDIKit", from: "0.4.4"),
         .package(url: "https://github.com/orchetect/TimecodeKit", from: "1.2.9")
     ],
 

--- a/Sources/MIDIKitSync/MTC/Receiver/MTC Receiver.swift
+++ b/Sources/MIDIKitSync/MTC/Receiver/MTC Receiver.swift
@@ -102,7 +102,7 @@ extension MIDI.MTC {
                                              _ displayNeedsUpdate: Bool) -> Void)? = nil
         
         /// Called when the MTC receiver's state changes
-        internal var stateChangedHandler: ((_ state: State) -> Void)? = nil
+        public var stateChangedHandler: ((_ state: State) -> Void)? = nil
         
         
         // MARK: - Init


### PR DESCRIPTION
not positive you want the dependency upped - though I needed to do that to allow correct xcodeproj creation on my end for the binary version.

main thing is just exposing that handler for disposal.

(PR to dev is giving me all these weird changes that i didn't make, so Just doing to main, you can disregard if you want, though i think the stateChangedHandler should be public)